### PR TITLE
add min/max zoom and keyboard zoom

### DIFF
--- a/city planning game/Assets/Scenes/SampleScene.unity
+++ b/city planning game/Assets/Scenes/SampleScene.unity
@@ -123,6 +123,53 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &384076833
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 384076835}
+  - component: {fileID: 384076834}
+  m_Layer: 0
+  m_Name: MouseInputObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &384076834
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 384076833}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3d0775b2028d66342830d9ad305465f9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  groundMask:
+    serializedVersion: 2
+    m_Bits: 64
+  mainCamera: {fileID: 963194227}
+--- !u!4 &384076835
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 384076833}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -32.362137, y: 24.944418, z: 36.313072}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &705507993
 GameObject:
   m_ObjectHideFlags: 0
@@ -225,7 +272,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 869510806}
-  - component: {fileID: 869510807}
   m_Layer: 0
   m_Name: CameraPivot
   m_TagString: Untagged
@@ -243,23 +289,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 963194228}
+  m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &869510807
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 869510805}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cc8aa4ea34916184493d7b13f654fc7e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &962006129
 GameObject:
   m_ObjectHideFlags: 0
@@ -290,7 +323,7 @@ Transform:
   - {fileID: 1869677422}
   - {fileID: 7378993158876129310}
   m_Father: {fileID: 0}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &963194225
 GameObject:
@@ -373,8 +406,8 @@ Transform:
   m_LocalPosition: {x: -17, y: 10, z: -17}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 869510806}
-  m_RootOrder: 0
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 30, y: 45, z: 0}
 --- !u!114 &963194229
 MonoBehaviour:
@@ -385,10 +418,60 @@ MonoBehaviour:
   m_GameObject: {fileID: 963194225}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d214e165cbd7f334eab78a9c6edb8983, type: 3}
+  m_Script: {fileID: 11500000, guid: cc8aa4ea34916184493d7b13f654fc7e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  parentObject: {fileID: 0}
+  target: {fileID: 869510806}
+  cameraPos: {fileID: 963194228}
+  X: 0
+  Y: 0
+  Z: 0
+  angularSpeed: 100
+--- !u!1 &1023918831
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1023918833}
+  - component: {fileID: 1023918832}
+  m_Layer: 0
+  m_Name: GameManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1023918832
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1023918831}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a55f8ac0df9139d4da78fec78e982738, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cameraControl: {fileID: 963194229}
+  mouseInput: {fileID: 384076834}
+--- !u!4 &1023918833
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1023918831}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -32.362137, y: 24.944418, z: 36.313072}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1869677421
 GameObject:
   m_ObjectHideFlags: 0
@@ -400,7 +483,7 @@ GameObject:
   - component: {fileID: 1869677422}
   - component: {fileID: 1869677424}
   - component: {fileID: 1869677423}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: Terrain
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/city planning game/Assets/Scripts/CameraControl.cs
+++ b/city planning game/Assets/Scripts/CameraControl.cs
@@ -17,11 +17,14 @@ public class CameraControl : MonoBehaviour
     Vector3 zoomOffset;
     Vector3 targetPos;
 
+    private float minCameraDistance = 3;
+    private float maxCameraDistance = 30;
+
     // Start is called before the first frame update
     void Start()
     {
         // Set camera offset from object
-        cameraOffset = new Vector3( 0, 5, -8 );
+        cameraOffset = new Vector3( 0, 5, -8);
 
         // Get target position to rotate around
         if ( target == null ) {
@@ -31,7 +34,7 @@ public class CameraControl : MonoBehaviour
         }
 
         // Set transform rotation and position
-        transform.rotation = Quaternion.Euler( 15, 0, 0 );
+        transform.rotation = Quaternion.Euler( 25, 0, 0 );
         transform.position = targetPos + cameraOffset;
     }
 
@@ -48,13 +51,18 @@ public class CameraControl : MonoBehaviour
 
         // Get scroll input and update offset
         float mouseScroll = Input.GetAxis( "Mouse ScrollWheel" );
+        if (Mathf.Approximately(mouseScroll, 0)){
+            //switch to key input if scroll wheel is none
+            mouseScroll = Input.GetAxis("Vertical");
+            //decrease speed to compensate for held keys
+            zoomOffset /= 10;
+        }
 
-        if ( mouseScroll > 0 ) {
+        if ( mouseScroll > 0 && cameraOffset.magnitude > minCameraDistance) {
             cameraOffset -= zoomOffset;
-        } else if ( mouseScroll < 0 ) {
+        } else if ( mouseScroll < 0 && cameraOffset.magnitude < maxCameraDistance) {
             cameraOffset += zoomOffset;
         }
-        
         // Update camera position
         transform.position = targetPos + cameraOffset;
     }


### PR DESCRIPTION
checks if camera offset is within a defined range before applying zoom offset

zoom control defaults to vertical axis if scroll axis is zero

## Changes
camera could zoom infinitely close or far - now it's clamped to a range
no keyboard input for zoom - now vertical axis should work as well as scroll wheel

## Type of Issue
Enhancement

## Reference Ticket
[Feature 3 - Camera](https://trello.com/c/tg7ArDf8/3-feature-3-camera)

## Checklist

- [X] Tested locally
- [x] Someone else test it

