### PR TITLE
basic mouse input

### DIFF
--- a/city planning game/Assets/Scripts/GameManager.cs
+++ b/city planning game/Assets/Scripts/GameManager.cs
@@ -1,0 +1,27 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class GameManager : MonoBehaviour
+{
+    public MouseInput mouseInput;
+    public GameObject testCube;
+
+    // Start is called before the first frame update
+    private void Start()
+    {
+        mouseInput.OnMouseDown += HandleMouseClick;
+    }
+
+    private void HandleMouseClick(Vector3 pos)
+    {
+        Debug.Log(pos);
+        Instantiate(testCube, pos, Quaternion.identity);
+        
+    }
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+}

--- a/city planning game/Assets/Scripts/GameManager.cs.meta
+++ b/city planning game/Assets/Scripts/GameManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a55f8ac0df9139d4da78fec78e982738
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/city planning game/Assets/Scripts/MouseInput.cs
+++ b/city planning game/Assets/Scripts/MouseInput.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+public class MouseInput : MonoBehaviour
+{
+    public Action<Vector3> OnMouseDown, OnMouseHold;
+    public Action OnMouseUp;
+    public LayerMask groundMask;
+
+    [SerializeField]
+    Camera mainCamera;
+
+    private void Update(){
+        CheckClickDownEvent();
+        CheckClickUpEvent();
+        CheckClickHoldEvent();
+    }
+
+    private Vector3? RaycastGround(){
+        RaycastHit hit;
+        Ray ray = mainCamera.ScreenPointToRay(Input.mousePosition);
+        if(Physics.Raycast(ray, out hit, Mathf.Infinity, groundMask)){
+            return hit.point;
+        }
+        return null;
+    }
+    private void CheckClickHoldEvent()
+    {
+        if(Input.GetMouseButton(0)){
+            var pos = RaycastGround();
+            if (pos != null){
+                OnMouseHold?.Invoke(pos.Value);
+                //Debug.Log("Hold: " + pos.Value);
+            }
+        }
+    }
+
+    private void CheckClickUpEvent()
+    {
+        if(Input.GetMouseButtonUp(0)){
+            OnMouseUp?.Invoke();
+        }
+
+    }
+
+    private void CheckClickDownEvent()
+    {
+        if(Input.GetMouseButtonDown(0)){
+            var pos = RaycastGround();
+            if (pos != null){
+                OnMouseDown?.Invoke(pos.Value);
+                //Debug.Log("Down: " + pos.Value);
+            }
+        }
+    }
+}

--- a/city planning game/Assets/Scripts/MouseInput.cs.meta
+++ b/city planning game/Assets/Scripts/MouseInput.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3d0775b2028d66342830d9ad305465f9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Changes
MouseInput triggers events for clickdown, clickup, and click-hold

click to place a cube and print the coordinates to console

currently does not have a system for avoiding UI element collision - this will need to be added later

## Type of Issue
Feature

## Reference Ticket
[Feature 2 - Building placement](https://trello.com/c/Rj1nJdZE/2-feature-2-building-placement)

## Checklist

- [X] Tested locally
- [ ] Tested by someone else

