### PR TITLE
unbind zoom from mouse scroll

### DIFF
--- a/city planning game/Assets/Scripts/CameraControl.cs
+++ b/city planning game/Assets/Scripts/CameraControl.cs
@@ -17,8 +17,8 @@ public class CameraControl : MonoBehaviour
     Vector3 zoomOffset;
     Vector3 targetPos;
 
-    private float minCameraDistance = 3;
-    private float maxCameraDistance = 30;
+    private float minCameraDistance = 5;
+    private float maxCameraDistance = 60;
 
     private int UILayer;
 
@@ -52,25 +52,15 @@ public class CameraControl : MonoBehaviour
         Z = cameraPos.position.z - targetPos.z;
 
         // Set zoom offset
-        zoomOffset = new Vector3( ( X / 10 ), ( Y / 10 ), ( Z / 10 ) );
+        zoomOffset = new Vector3( ( X / 200 ), ( Y / 200 ), ( Z / 200 ) );
 
-        // Get scroll input and update offset
-        float mouseScroll = 0;
-        if ( !Util.IsPointerOverLayer( UILayer ) )
-        {
-            mouseScroll = Input.GetAxis( "Mouse ScrollWheel" );
-        }
+        // Get zoom input 
+        float zoomInput = Input.GetAxis("Vertical");
 
-        if (Mathf.Approximately(mouseScroll, 0)){
-            //switch to key input if scroll wheel is none
-            mouseScroll = Input.GetAxis("Vertical");
-            //decrease speed to compensate for held keys
-            zoomOffset /= 10;
-        }
-
-        if ( mouseScroll > 0 && cameraOffset.magnitude > minCameraDistance) {
+        //update offset
+        if ( zoomInput > 0 && cameraOffset.magnitude > minCameraDistance) {
             cameraOffset -= zoomOffset;
-        } else if ( mouseScroll < 0 && cameraOffset.magnitude < maxCameraDistance) {
+        } else if ( zoomInput < 0 && cameraOffset.magnitude < maxCameraDistance) {
             cameraOffset += zoomOffset;
         }
         // Update camera position

--- a/city planning game/ProjectSettings/InputManager.asset
+++ b/city planning game/ProjectSettings/InputManager.asset
@@ -29,7 +29,7 @@ InputManager:
     positiveButton: up
     altNegativeButton: s
     altPositiveButton: w
-    gravity: 3
+    gravity: 10
     dead: 0.001
     sensitivity: 3
     snap: 1


### PR DESCRIPTION
## Changes
- removes scroll zooming, as that currently rotates buildings
- changes input gravity and offset weighting to improve feel of keyboard zoom

## Type of Issue
Bugfix

## Reference Ticket
[issue 14](https://github.com/chemelia/city-planning-game/issues/14)

## Checklist
- [X] Tested locally
- [ ] Checked/reviewed
