### PR TITLE
building prefab bugfixes

### DIFF
--- a/city planning game/Assets/Prefabs/Buildings/HouseSmall.prefab
+++ b/city planning game/Assets/Prefabs/Buildings/HouseSmall.prefab
@@ -90,6 +90,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 6262953333801497772}
+  - component: {fileID: 943454527574739498}
   - component: {fileID: 3728850503334862105}
   - component: {fileID: 2538615943550538286}
   - component: {fileID: 6214605086695678209}
@@ -117,6 +118,23 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1818360609 &943454527574739498
+RotationConstraint:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2008035343353864571}
+  m_Enabled: 1
+  m_Weight: 1
+  m_RotationAtRest: {x: 0, y: 0, z: 0}
+  m_RotationOffset: {x: 0, y: 0, z: 0}
+  m_AffectRotationX: 1
+  m_AffectRotationY: 0
+  m_AffectRotationZ: 1
+  m_IsContraintActive: 1
+  m_IsLocked: 1
+  m_Sources: []
 --- !u!114 &3728850503334862105
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -163,7 +181,7 @@ Rigidbody:
   m_UseGravity: 0
   m_IsKinematic: 1
   m_Interpolate: 0
-  m_Constraints: 0
+  m_Constraints: 80
   m_CollisionDetection: 0
 --- !u!1 &3792663428270404345
 GameObject:

--- a/city planning game/Assets/Scripts/Building.cs
+++ b/city planning game/Assets/Scripts/Building.cs
@@ -52,7 +52,6 @@ public class Building : MonoBehaviour
         currState = PlacementState.Hover;
         currPoints = 0;
         numCollisions = 0;
-
         radius.SetActive( true );
 
         // TODO: fix text
@@ -64,6 +63,9 @@ public class Building : MonoBehaviour
 
     // TODO: if building is in hover state, constantly check for surrounding buildings and update points value
     
+    void OnGUI() {
+        points.transform.LookAt(Camera.main.transform);
+    }
     void OnCollisionEnter()
     {
         numCollisions++;
@@ -95,4 +97,5 @@ public class Building : MonoBehaviour
         }
         return false;
     }
+
 }

--- a/city planning game/Assets/Scripts/PlacementController.cs
+++ b/city planning game/Assets/Scripts/PlacementController.cs
@@ -50,7 +50,7 @@ public class PlacementController : MonoBehaviour
         if (Physics.Raycast(ray, out hitInfo, 100.0f, layerMask))
         {
             currentPlaceableObject.transform.position = hitInfo.point;
-            currentPlaceableObject.transform.rotation = Quaternion.FromToRotation(Vector3.up, hitInfo.normal);
+            currentPlaceableObject.transform.rotation = Quaternion.Euler(Vector3.zero);
         }
     }
 


### PR DESCRIPTION
## Changes
- score text always faces camera
- buildings remain level and don't slope with terrain

## Type of Issue
Bugfix

## Reference Ticket
[Issue 17 - buildings rotate with terrain slope](https://github.com/chemelia/city-planning-game/issues/17)
[Issue 18 - score text doesnt rotate with camera](https://github.com/chemelia/city-planning-game/issues/18)

## Checklist
- [X] Tested locally
- [x] Checked/reviewed
