### PR TITLE
Remove building indicators when deselcting a building

### DIFF
--- a/city planning game/Assets/Scripts/Building.cs
+++ b/city planning game/Assets/Scripts/Building.cs
@@ -104,11 +104,7 @@ public class Building : MonoBehaviour
         }
 
         // We can probably do this real inefficiently cuz the number of buildings is so small I hope
-        foreach (var hitBuilding in activeBuildings)
-        {
-            hitBuilding.GetComponent<Building>().indicator.SetActive( false );
-        }
-
+        ClearIndicators();
         foreach (var hitBuilding in newActiveBuildings)
         {
             hitBuilding.GetComponent<Building>().indicator.SetActive( true );
@@ -157,12 +153,17 @@ public class Building : MonoBehaviour
         currState = PlacementState.Placed;
         currPoints = ComputeScore();
 
+        ClearIndicators();
+
+        return ( currPoints );
+    }
+
+    public void ClearIndicators()
+    {
         foreach (var hitBuilding in activeBuildings)
         {
             hitBuilding.GetComponent<Building>().indicator.SetActive( false );
         }
-
-        return ( currPoints );
     }
 
     public List<GameObject> getActiveBuildings()

--- a/city planning game/Assets/Scripts/PlacementController.cs
+++ b/city planning game/Assets/Scripts/PlacementController.cs
@@ -23,6 +23,9 @@ public class PlacementController : MonoBehaviour
     {
         if ( Input.GetKeyDown( KeyCode.Escape )  || Input.GetKeyDown(KeyCode.Mouse1))
         {
+            var building = currentPlaceableObject.GetComponent<Building>();
+            building.ClearIndicators();
+
             Destroy( currentPlaceableObject );
         }
 


### PR DESCRIPTION
## Changes
Fix bug with building indicators still being displayed after deselecting a building.

## Type of Issue
Bug

## Reference Ticket
N/A

## Checklist

- [x] Tested locally

