### PR TITLE
Remove escape as a building deselection option

### DIFF
--- a/city planning game/Assets/Scripts/PlacementController.cs
+++ b/city planning game/Assets/Scripts/PlacementController.cs
@@ -21,7 +21,7 @@ public class PlacementController : MonoBehaviour
 
     void Update()
     {
-        if ( Input.GetKeyDown( KeyCode.Escape )  || Input.GetKeyDown(KeyCode.Mouse1))
+        if ( Input.GetKeyDown(KeyCode.Mouse1) )
         {
             DeselectBuilding();
         }


### PR DESCRIPTION
## Changes
Remove escape as an option to deselect building cuz it triggers pause menu now.
